### PR TITLE
fix: custom graph creation

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -15,7 +15,9 @@ module.exports = function(app) {
 
   app.use(morgan(logFormat))
   app.use(compression())
-  app.use(bodyParser.json())
+  app.use(bodyParser.json({
+    type: ['application/json', 'application/vnd.api+json']
+  }))
 
   routes.providers(injections, app, `${rootURL}api/providers`)
   routes.projects(injections, app, `${rootURL}api/projects`)


### PR DESCRIPTION
Fixes custom graph creation/edition.

At some point in an update the `JSONAPIAdapter` switched to using `application/vnd.api+json` content-type, which perfos server `bodyParser` middleware is not configured to handle (by default it only handles `application/json`. As a consequence, custom graph creation and edition behaves as if the client sent an empty payload.

This PR configures the middleware to accept both content types.